### PR TITLE
Various fix

### DIFF
--- a/bin_pack.c
+++ b/bin_pack.c
@@ -241,11 +241,11 @@ static BINPACK_INLINE int do_unpack_int(bin_unpacker_t *packer, intmax_t *p_valu
     return 0;
 }
 
-static BINPACK_INLINE int do_unpack_unit(bin_unpacker_t *packer, intmax_t *p_value)
+static BINPACK_INLINE int do_unpack_unit(bin_unpacker_t *packer, uintmax_t *p_value)
 {
     uintmax_t num;
 
-    int type = bin_unpack_type(packer, (uintmax_t*)p_value);
+    int type = bin_unpack_type(packer, &num);
     int sign = type & BIN_MASK_INTEGER_SIGN;
 
     if (type < BIN_TYPE_INTEGER || sign)

--- a/bin_pack.c
+++ b/bin_pack.c
@@ -95,7 +95,7 @@ static BINPACK_INLINE size_t do_pack_tag(char *buf, int type, uintmax_t num)
 BINPACK_INLINE size_t bin_int_buffer(char *buf, intmax_t value)
 {
     return value >= 0 ? do_pack_intstr(buf, BIN_TYPE_INTEGER, value)
-        : do_pack_intstr(buf, BIN_TYPE_INTEGER_NEGATIVE, -value);
+        : do_pack_intstr(buf, BIN_TYPE_INTEGER_NEGATIVE, -(uintmax_t)value);
 }
 
 BINPACK_INLINE size_t bin_uint_buffer(char *buf, uintmax_t value)

--- a/bin_pack.c
+++ b/bin_pack.c
@@ -37,19 +37,6 @@ static const char rcsid[] = "$Id: bin_pack.c, huqiu Exp $";
 #define SSIZE_MAX	(SIZE_MAX/2)
 #endif
 
-static const char *binpack_tpnames[] = {
-    "UNKNOWN",	/*  0 */
-    "CLOSURE",	/*  1 */
-    "LIST",		/*  2 */
-    "DICT",		/*  3 */
-    "BOOL",		/*  4 */
-    "DOUBLE",	/*  5 */
-    "FLOAT",	/*  5 */
-    "NULL",		/*  7 */
-    "STRING",	/*  8 */
-    "DOUBLE",	/*  9 */
-    "INTEGER",	/* 10 */
-};
 
 static BINPACK_INLINE size_t do_pack_intstr(char *buf, int type, uintmax_t num)
 {

--- a/bin_pack.c
+++ b/bin_pack.c
@@ -25,6 +25,7 @@
 #include "bin_pack_endian.h"
 
 #include <stdio.h>
+#include <arpa/inet.h>
 
 #ifdef CUBE_LIB_RCSID
 static const char rcsid[] = "$Id: bin_pack.c, huqiu Exp $";

--- a/php_binpack.c
+++ b/php_binpack.c
@@ -259,7 +259,7 @@ static void binpack_encode_array(bin_packer_t *pk, zval *arr TSRMLS_DC)
 
 	if (num > 0)
 	{
-		long idx;
+		ulong idx;
 		char *key;
 		uint key_len;
 		HashPosition pos;

--- a/php_binpack.c
+++ b/php_binpack.c
@@ -76,7 +76,7 @@ zend_module_entry binpack_module_entry = {
 	NULL,		/* Replace with NULL if there's nothing to do at request end */
 	PHP_MINFO(binpack),
 #if ZEND_MODULE_API_NO >= 20010901
-	"0.1", /* Replace with version number for your extension */
+	BINPACK_EXTENSION_VERSION, /* Replace with version number for your extension */
 #endif
 	STANDARD_MODULE_PROPERTIES
 };


### PR DESCRIPTION
814309d fix an undefined behavior which cause build failure with gcc 4.9 and -O2.

Please check 1a99bf1

For da1c36b I'd like to use #ifdef HAVE_ARPA_INET_H but php_config.h is not included in this part.
