### PR TITLE
check for <arpa/inet.h> header

### DIFF
--- a/bin_pack.c
+++ b/bin_pack.c
@@ -14,18 +14,23 @@
   +----------------------------------------------------------------------+
 */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdlib.h>
-#include <stdint.h>         
+#include <stdint.h>
 #include <limits.h>
 #include <assert.h>
 #include <string.h>
 #include <stdarg.h>
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
 
 #include "bin_pack.h"
 #include "bin_pack_endian.h"
 
 #include <stdio.h>
-#include <arpa/inet.h>
 
 #ifdef CUBE_LIB_RCSID
 static const char rcsid[] = "$Id: bin_pack.c, huqiu Exp $";

--- a/config.m4
+++ b/config.m4
@@ -57,6 +57,7 @@ if test "$PHP_BINPACK" != "no"; then
   dnl
   dnl PHP_SUBST(BINPACK_SHARED_LIBADD)
 
+  AC_CHECK_HEADERS([arpa/inet.h])
   PHP_NEW_EXTENSION(binpack, bin_pack.c php_binpack.c, $ext_shared)
 
   ifdef([PHP_INSTALL_HEADERS],


### PR DESCRIPTION
Seems better to check for this header, as I don't know how is it portable...
